### PR TITLE
Custom health handler + refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build
 513
 .rocks
+.idea/
 *.snap
 *.xlog
 *.vylog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `cartridge.roles.metrics` from `metrics` repository
+- Function ``set_health_handler`` has been added to role ``cartridge.roles.metrics``,
+  allowing you to set your own handle to check health
+  (`tarantool/cartridge#2097 <https://github.com/tarantool/cartridge/issues/2097>`_).
+  Main case - customizing the response format.

--- a/cartridge/roles/metrics.lua
+++ b/cartridge/roles/metrics.lua
@@ -4,6 +4,7 @@ local hotreload_supported, hotreload = pcall(require, 'cartridge.hotreload')
 local metrics = require('metrics')
 local metrics_stash = require('metrics.stash')
 local log = require('log')
+local health = require('cartridge.health')
 
 local metrics_vars = require('cartridge.vars').new('metrics_vars')
 metrics_vars:new('current_paths', {})
@@ -21,10 +22,7 @@ local handlers = {
         local http_handler = require('metrics.plugins.prometheus').collect_http
         return http_handler(...)
     end,
-    ['health'] = function(...)
-        local http_handler = require('cartridge.health').is_healthy
-        return http_handler(...)
-    end,
+    ['health'] = health.default_is_healthy_handler,
 }
 
 local function set_labels(custom_labels)
@@ -240,6 +238,17 @@ local function stop()
     metrics_vars.custom_labels = {}
 end
 
+local function set_health_handler(new_handler)
+    handlers['health'] = new_handler or health.default_is_healthy_handler
+
+    local paths = table.copy(metrics_vars.current_paths)
+    for path, _ in pairs(metrics_vars.current_paths) do
+        metrics_vars.current_paths[path] = ''
+    end
+
+    apply_routes(paths)
+end
+
 return setmetatable({
     role_name = 'metrics',
     permanent = true,
@@ -249,4 +258,5 @@ return setmetatable({
     apply_config = apply_config,
     set_export = set_export,
     set_default_labels = set_default_labels,
+    set_health_handler = set_health_handler,
 }, { __index = metrics })

--- a/test/integration/cartridge_health_test.lua
+++ b/test/integration/cartridge_health_test.lua
@@ -30,12 +30,46 @@ g.after_each(function()
     end)
 end)
 
+g.after_test('test_metrics_custom_is_health_handler', function()
+    local main_server = g.cluster:server('main')
+    main_server:exec(function()
+        local cartridge = require('cartridge')
+        local metrics = cartridge.service_get('metrics')
+        metrics.set_health_handler(nil)
+    end)
+end)
+
 g.test_cartridge_health_handler = function()
     helpers.skip_cartridge_version_less('2.0.2')
     helpers.upload_default_metrics_config(g.cluster)
     local main_server = g.cluster:server('main')
     local resp = main_server:http_request('get', '/health', {raise = false})
     t.assert_equals(resp.status, 200)
+end
+
+g.test_metrics_custom_is_health_handler = function()
+    helpers.upload_default_metrics_config(g.cluster)
+    local main_server = g.cluster.main_server
+
+    main_server:exec(function()
+        local cartridge = require('cartridge')
+        local metrics = cartridge.service_get('metrics')
+        metrics.set_health_handler(function(req)
+            local health = require('cartridge.health')
+            local resp = req:render{
+                json = {
+                    my_healthcheck_format = health.is_healthy()
+                }
+            }
+            resp.status = 200
+            return resp
+        end)
+    end)
+
+    local resp = main_server:http_request('get', '/health', {raise = false})
+    t.assert_equals(resp.status, 200)
+    t.assert_equals(type(resp.json), 'table')
+    t.assert_equals(resp.json, { my_healthcheck_format = true })
 end
 
 g.test_cartridge_health_fail_handler = function()


### PR DESCRIPTION
See problem description [here](https://github.com/tarantool/cartridge-metrics-role/issues/4)
I propose to give the user the function of setting their own handler to check health.

``` lua
local metrics = require('cartridge.roles.metrics')
metrics.set_custom_is_health_handler(function(req)
    local health = require('cartridge.health')
    local resp = req:render{
        json = {
            my_healthcheck_format = health.is_healthy()
        }
    }
    resp.status = 200
    return resp
end)
```

# Changes
- `metrics.lua` - added function `set_custom_health_handler`, subj
- `health.lua` - divided one function `is_healthy` to three: `is_healthy`, `is_healthy_handler`, `member_is_healthy` - the content of each of which is consistent with the title
- `rpc.lua` - We have a code repetition, and a text link to the original piece is made from the health module. So, replaced code to use `health.member_is_healthy`, and rename `member_is_healthy` to `instance_is_healthy`, because he argument is instance

# Checklist
- [x] Tests
- [x] Changelog
- [x] Documentation

# Links
Close tarantool/cartridge-metrics-role#4 