### PR TITLE
ci: run on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,14 @@ on:
   push:
     branches:
      - '**'
+  pull_request:
+
 jobs:
   test:
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Now CI doesn't run on pull requests. In that case, it is easy to miss if something has been broken if you're a collaborator. (For example, see [1].)

1. https://github.com/tarantool/cartridge-metrics-role/pull/8

I didn't forget about
- [x] Tests
